### PR TITLE
chore(build): add headers and libs path for macOS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,8 +20,14 @@ AM_CXXFLAGS+=-framework WebKit
 AM_CFLAGS+=-framework WebKit
 if ARM
 # Flags for macOS ARM
+AM_CXXFLAGS+=-I/opt/homebrew/include
+AM_CFLAGS+=-I/opt/homebrew/include
+AlicornCH_LDFLAGS+=-L/opt/homebrew/lib
 else
 # Flags for macOS x86
+AM_CXXFLAGS+=-I/usr/local/include
+AM_CFLAGS+=-I/usr/local/include
+AlicornCH_LDFLAGS+=-L/usr/local/lib
 endif
 endif
 


### PR DESCRIPTION
Added the HomeBrew general include and lib path. 
There may be some problems for the OpenSSL because HomeBrew didn't make a symbolic link for it while installing. 