### PR TITLE
fix(lurl): remove calling to atoi()

### DIFF
--- a/src/libimpl/lurl.cc
+++ b/src/libimpl/lurl.cc
@@ -30,8 +30,9 @@
 #include "lurl.hpp"
 
 #include <algorithm>
+#include <cerrno>
+#include <cstdlib>
 #include <cstring>
-#include <stdlib.h>
 
 namespace
 {
@@ -57,9 +58,15 @@ LUrlParser::ParseURL::getPort(int *outPort) const
       return false;
     }
 
-  const int port = atoi(port_.c_str());
+  errno = 0; // Reset errno
+  const long long port = strtoll(port_.c_str(), nullptr, 10);
 
-  if(port <= 0 || port > 65535)
+  if(errno == EINVAL || errno == ERANGE) // Failed to parse the port
+    {
+      return false;
+    }
+
+  if(port < 0 || port > 65535)
     {
       return false;
     }


### PR DESCRIPTION
Passing invalid string to `atoi()` is an undefined behaviour. The man page discourage the usage of it.
This commit fixes the bug.

Payload to reproduce the bug:
```cpp
  LUrlParser::ParseURL url = LUrlParser::ParseURL::parseURL("https://www.baidu.com:4294987294");
  int port = 443;
  std::cout << url.port_ << std::endl;
  std::cout << url.getPort(&port) << std::endl;
  std::cout << port << std::endl;
```

Wanted output:
```
4294987294
0
443
```

Actual output on x86_64 linux glibc (before this commit)
```
4294987294
1
19998
```